### PR TITLE
Add misc scripts to external_tools

### DIFF
--- a/external_tools/data_migrations/README.txt
+++ b/external_tools/data_migrations/README.txt
@@ -1,0 +1,5 @@
+Data Migrations
+
+Contains code & publicly-visible data files associated with one-time changes to
+ data structure or contents within the MedBook database
+

--- a/external_tools/data_migrations/reference_cohort_august_2016/add_samples_to_dataset.py
+++ b/external_tools/data_migrations/reference_cohort_august_2016/add_samples_to_dataset.py
@@ -1,0 +1,59 @@
+#! /usr/bin/env python
+
+"""
+# given a dataset json,
+manually add the sample_labels, sample_label_index , feature_labels
+
+Usage:
+export dataset json from mongo
+./add_samples_to_dataset.py > dataset_with_samples.json
+import new dataset json to mongo
+
+Requires the following files to exist in the pwd:
+    -- dataset.json : dump of the existing dataset without sample labels, etc
+    -- samples : list of sample IDs with study lables prepended
+    -- features : list of feature names
+"""
+
+import json
+import sys
+
+# Are all elements of x unique
+def uniq(x):
+    seen = set()
+    return not any(i in seen or seen.add(i) for i in x)
+
+
+def main():
+
+    with open("dataset.json") as dataset:
+        data = json.load(dataset)
+
+    with open("samples") as samplines:
+        samples = [s.rstrip() for s in samplines.readlines()]
+    with open("features") as featurelines:
+        features = [f.rstrip() for f in featurelines.readlines()]
+
+    # Require unique lists
+    if((not uniq(samples)) or (not uniq(features))):
+        print "Samples not unique!"   
+        sys.exit(1)
+ 
+
+    # study qualifer needs to already be present
+    data["sample_labels"] = samples 
+
+    # sample label index
+    sample_label_index = {}
+    for idx, sample in enumerate(samples):
+        sample_label_index[sample] = idx
+
+    data["sample_label_index"] = sample_label_index
+    data["feature_labels"] = features
+
+    print (json.dumps(data))
+    sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/external_tools/data_migrations/reference_cohort_august_2016/make_new_samplegroups.py
+++ b/external_tools/data_migrations/reference_cohort_august_2016/make_new_samplegroups.py
@@ -1,0 +1,58 @@
+import sys
+import json
+
+# Given file fix_these_samplegroups
+# make new samplegroups that are the same
+# except old_dataset replaced by new_dataset
+# and print
+# with additional javascript code to write them to the database
+
+def print_make_sg(data):
+  obj = json.dumps(data)
+  print(obj + ",")
+
+def main():
+    
+  # print the beginning of the samplegroup list
+  print("var sgroups = [")
+
+  # print each samplegroup
+  
+  new_dataset_id = sys.argv[1]
+  old_dataset_id = sys.argv[2]
+
+  with open("fix_these_samplegroups") as inp:
+    for line in inp:
+      data = json.loads(line)
+      newdata = {}
+      newdata["name"] = data["name"]
+      newdata["version"] = data["version"]
+      newdata["collaborations"] = data["collaborations"]
+      newdata["data_sets"] = []
+      # Go through datasets, update ID to new if it's the old one
+      # and leave it the same otherwise
+      for dataset in data["data_sets"]:
+        new_ds = {}
+        new_ds["filters"] = dataset["filters"]
+        from_ds_id = dataset["data_set_id"]
+        if from_ds_id == old_dataset_id:
+          new_ds["data_set_id"] = new_dataset_id
+        else:
+          new_ds["data_set_id"] = from_ds_id
+        newdata["data_sets"].append(new_ds)
+      # output the sample group
+      print_make_sg(newdata)
+
+  # print the rest of it
+  remaining_contents = """]
+  for( item of sgroups){
+    Meteor.call("createSampleGroup", item, (e,r) => {
+      if(e){console.log("ERROR ",e);}
+      else{console.log("RAN ",r);} 
+    });
+  }
+"""
+  print(remaining_contents)
+
+if __name__ == "__main__" :
+  main()

--- a/external_tools/data_migrations/reference_cohort_august_2016/migration_summary.txt
+++ b/external_tools/data_migrations/reference_cohort_august_2016/migration_summary.txt
@@ -1,0 +1,22 @@
+
+Add new Reference Cohort and update sample groups
+Data migration performed Friday August 19th, 2016
+
+ORR: "DONE ORR: Add unfiltered CKCC Reference Cohort to mongo. August 19 2016"
+See this ORR in Google Docs for detailed steps and usage of scripts.
+
+Pre-generated files not included in this archive (see ORR for re-generation):
+ - features
+ - samples
+ - update_ckcc_study.json
+
+
+Task:
+When the existing CKCC Reference Cohort was imported into MedBook, two filters
+were applied to it before import which dropped some genes from the cohort.
+Medbook now has the capability to apply those filters on the fly, so a new
+copy of the reference cohort was imported, which did not have those filters
+applied.
+
+Then, for each sample group which referred to the original copy of the cohort,
+a new version of that sample group was created referring to the new cohort.

--- a/external_tools/data_migrations/reference_cohort_august_2016/new_samplegroups.sh
+++ b/external_tools/data_migrations/reference_cohort_august_2016/new_samplegroups.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Usage: /new_samplegroups.sh NewCohortDatasetID OldCohortDatasetId
+# export the sample groups using the targeted data set 
+# use the OLD cohort dataset id
+echo $2
+query='{"data_sets.data_set_id" : "'$2'"}'
+echo $query
+#PROD
+# mongoexport --host mongo -d MedBook -c sample_groups -q "$query" > fix_these_samplegroups
+#staging 
+mongoexport --host mongo-staging -d MedBook -c sample_groups -q "$query" > fix_these_samplegroups
+python make_new_samplegroups.py $1 $2 > new_samplegroups.js
+echo Make a snippet with new_samplegroups.js and run it in a logged-in browser client!

--- a/external_tools/data_migrations/reference_cohort_august_2016/update_dataset.sh
+++ b/external_tools/data_migrations/reference_cohort_august_2016/update_dataset.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+
+datasetId=$1
+
+echo exporting datasets...
+# PROD
+#mongoexport --db MedBook --host mongo --collection data_sets > all_datasets
+
+# staging
+mongoexport --db MedBook --host mongo-staging --collection data_sets > all_datasets
+
+echo finding dataset $datasetId ...
+grep $datasetId all_datasets > dataset.json
+
+echo updating dataset with samples...
+./add_samples_to_dataset.py > dataset_with_samples.json
+
+echo importing new dataset info...
+#PROD
+#mongoimport --db MedBook --host mongo --collection data_sets --file dataset_with_samples.json --upsert
+
+#STAGING
+ mongoimport --db MedBook --host mongo-staging --collection data_sets --file dataset_with_samples.json --upsert
+
+echo now you import the gene expression connected to this dataset.

--- a/external_tools/data_migrations/reference_cohort_august_2016/update_samplegroups.js
+++ b/external_tools/data_migrations/reference_cohort_august_2016/update_samplegroups.js
@@ -1,0 +1,38 @@
+
+// For Expression & Variance Filters 
+// Rename the CKCC reference cohort
+// Add me to its sample groups
+// Rename it in its sample groups
+
+var new_dataset_name = "CKCC Reference Cohort (pre-filtered)" ;
+var dataset_id = // "DATASET ID REMOVED" ;
+var add_user = // "COLLABORATION STRING REMOVED" ;
+// Rename the dataset
+db.data_sets.update({_id: dataset_id}, {$set: {name: new_dataset_name}})
+// For each of its sample groups
+db.sample_groups.find({"data_sets.data_set_id" : dataset_id}).forEach(function (sg) {
+  print(sg._id);
+  // Add me to its collaborations
+  db.sample_groups.update(
+  {"_id" : sg._id},
+  {
+    $push: {
+      "collaborations": add_user,
+    }
+  });
+  // Then update the dataset name
+  sg.data_sets.forEach(function(ds){
+    if(ds.data_set_id === dataset_id){
+      ds.data_set_name = new_dataset_name ;
+    }
+  });
+  // And write that update to the database
+  db.sample_groups.update(
+  {
+    "_id" : sg._id,
+  },
+  {$set:
+    {data_sets : sg.data_sets}
+  }
+  );
+});

--- a/external_tools/export_outlier_tsv/README.txt
+++ b/external_tools/export_outlier_tsv/README.txt
@@ -1,0 +1,41 @@
+August 29, 2016
+
+A hacked-together script for quickly creating a TSV of outlier analysis
+results & uploading to the Treehouse directory.
+
+Not "production quality".
+
+Must be run by someone with ssh access to both the production server and the 
+Treehouse directory.
+
+What it does:
+============
+Connects to production server
+Pulls the requested outlier job results out of the database
+Uses a python script to convert it to a custom tsv format
+Using SFTP, downloads that tsv
+Using SFTP, reuploads that tsv to the Treehouse directory.
+
+
+Installation:
+==============
+On prod:
+====
+- have python 2.7 installed
+- put everything in the 'prod' folder in a folder somewhere
+  - the laptop script assumes it's located at ~/prod
+
+On your laptop:
+====
+ - put run_maketab.sh in a folder somewhere
+ - make an "already_transferred" subfolder
+ - replace the values in run_maketab.sh as appropriate
+
+Usage:
+======
+  ./run_maketab.sh MONGO_ID.
+
+
+
+
+

--- a/external_tools/export_outlier_tsv/prod/do_all_oa.sh
+++ b/external_tools/export_outlier_tsv/prod/do_all_oa.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Run on prod.
+# Give it a list of mongo IDs, and it will pull them all into TSVs
+# that go into the results/ subdir.
+
+# usage
+# do_all_oa.sh < FILE
+# FILE contains the outlier analysis job IDs, one per line
+mkdir -p results
+while read line;
+do
+  ./get_oa.sh $line
+done
+mv *.tsv results/

--- a/external_tools/export_outlier_tsv/prod/get_oa.sh
+++ b/external_tools/export_outlier_tsv/prod/get_oa.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+echo $1
+query="{_id:'"$1"'},{'output.up_genes':1, 'output.down_genes':1}"
+#cmd='mongoexport --host mongo -d MedBook -c jobs -q "'$query'"'
+#echo $cmd
+mongoexport --host mongo -d MedBook -c jobs -q "$query" > result.json
+python outlier_json_to_tsv.py

--- a/external_tools/export_outlier_tsv/prod/outlier_json_to_tsv.py
+++ b/external_tools/export_outlier_tsv/prod/outlier_json_to_tsv.py
@@ -1,0 +1,33 @@
+import sys
+import json
+import csv
+
+def main():
+  print("start")
+  with open("result.json") as inp:
+    data = json.load(inp)
+    samp = data["args"]["sample_label"].split("/")
+    if(len(samp) == 1):
+      samplename = samp[0]
+    else:
+      samplename = samp[1]
+    with open(("%s.tsv" % samplename), "w") as out:
+      print >>out,"SAMPLE: %s" % samplename
+      print >>out,"BACKGROUND: %s" % data["args"]["sample_group_name"]
+      print >>out,"IQR: %s" % data["args"]["iqr_multiplier"]
+      writer = csv.writer(out, delimiter="\t",lineterminator="\n")
+      writer.writerow(["feature_label", "sample_value", "background_median", "outlier_status"])
+      upgenes = data["output"]["up_genes"]
+      for obj in upgenes:
+        writer.writerow([obj["gene_label"],obj["sample_value"],obj["background_median"],"UP"])
+      downgenes = data["output"]["down_genes"]
+      for obj in downgenes:
+        writer.writerow([obj["gene_label"],obj["sample_value"],obj["background_median"],"DOWN"])
+
+  print("done")
+
+
+
+if __name__ == "__main__" :
+  main()
+   

--- a/external_tools/export_outlier_tsv/run_maketab.sh
+++ b/external_tools/export_outlier_tsv/run_maketab.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# replace PRODNAME, DIR, and STORAGENAME & STORAGEDIR
+# with appropriate values
+
+ssh PRODNAME "cd DIR; ./get_oa.sh $1"
+sftp PRODNAME <<EOF
+cd DIR
+get *.tsv
+EOF
+sftp STORAGENAME << EOF
+cd STORAGEDIR
+put *.tsv
+EOF
+mv *.tsv already_transferred/


### PR DESCRIPTION
adds 2 scripts to /external_tools (ie, won't be loaded by any any app) so that they have somewhere to live in a source-controlled environment.

-- creates a 'data migrations' subdir for 1-time scripts that are applied to the db but aren't a real schema-change migration ; adds the reference-cohort migration code to that

-- also adds the quick script for pulling outlier analysis tsvs.
