### PR TITLE
Can specify route name for searchable jobs

### DIFF
--- a/patient-care/webapp/client/shared/searchableJobs.html
+++ b/patient-care/webapp/client/shared/searchableJobs.html
@@ -93,7 +93,8 @@
       {{> listSelectableJobs jobsQuery=jobsQuery columns=columns
           selectMode=selectModeReactiveVar
           selectedIdMap=selectedIdMapReactiveVar
-          paginationOptions=paginationOptions}}
+          paginationOptions=paginationOptions
+          viewJobRouteName=viewJobRouteName}}
     {{else}}
       {{#if getInstanceReactive "searchText"}}
         <div class="ui message">
@@ -146,7 +147,7 @@
     </thead>
     <tbody>
       {{! this #let makes it so columns is defined within the #each}}
-      {{#let columns=columns}}
+      {{#let columns=columns viewJobRouteName=viewJobRouteName}}
         {{#each jobsQuery}}
           <tr class="select-job {{activeIfSelected}}">
             {{#each columns}}
@@ -156,7 +157,7 @@
             {{/each}}
 
             <td>
-              {{> viewJobButton href=(pathFor "upDownGenesJob" job_id=_id)
+              {{> viewJobButton href=(pathFor viewJobRouteName job_id=_id)
                   job=this}}
             </td>
           </tr>

--- a/patient-care/webapp/client/tools/listLimmaGSEA.html
+++ b/patient-care/webapp/client/tools/listLimmaGSEA.html
@@ -72,7 +72,8 @@
 
   <div class="ui divider"></div>
 
-  {{> searchableJobs name="RunLimmaGSEA" columns=previousJobsCols}}
+  {{> searchableJobs name="RunLimmaGSEA" columns=previousJobsCols
+      viewJobRouteName="limmaGseaJob"}}
 </template>
 
 <template name="limmaGSEAGroupSelector">

--- a/patient-care/webapp/client/tools/listUpDownGenes.html
+++ b/patient-care/webapp/client/tools/listUpDownGenes.html
@@ -68,5 +68,6 @@
     </button>
   {{/autoForm}}
 
-  {{> searchableJobs name="UpDownGenes" columns=previousJobsCols}}
+  {{> searchableJobs name="UpDownGenes" columns=previousJobsCols
+      viewJobRouteName="upDownGenesJob"}}
 </template>


### PR DESCRIPTION
Fixes a bug where `searchableJobs` would always redirect to the outlier analysis page regardless of the type of job. 