### PR TITLE
Bump job-runner tags to refresh cbio tools

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
   job-runner:
     container_name: "job-runner"
     restart: always
-    image: medbook/job-runner:v1.1.7
+    image: medbook/job-runner:v1.1.8
     volumes:
       - /filestore:/filestore
     environment:


### PR DESCRIPTION
Bumps the docker images after #65. I forgot that the `/tools` folder is added to the docker image on build as opposed to being mapped in at runtime, so we didn't bump the tags with #65. 